### PR TITLE
Add wrapper action for missing-in-project

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,37 @@
+---
+name: "Missing In Project (pinned)"
+description: >
+  Wrapper around LabVIEW-Community-CI-CD/missing-in-project that pins
+  the underlying action to a known good commit.
+
+inputs:
+  lv-ver:
+    description: "LabVIEW version (e.g. '2021')."
+    required: true
+  arch:
+    description: "Bitness (32 or 64)."
+    required: true
+  project-file:
+    description: >
+      Path to the .lvproj to inspect. Defaults to `main.lvproj`.
+    required: false
+    default: main.lvproj
+
+outputs:
+  passed:
+    description: "True if VI reported success."
+    value: ${{ steps.inner.outputs.passed }}
+  missing-files:
+    description: "Comma-separated list of missing files."
+    value: ${{ steps.inner.outputs['missing-files'] }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run upstream action
+      id: inner
+      uses: LabVIEW-Community-CI-CD/missing-in-project@6ef6511c58cbf74dca00498b5e05ca5690515f48  # yamllint disable-line rule:line-length
+      with:
+        lv-ver: ${{ inputs.lv-ver }}
+        arch: ${{ inputs.arch }}
+        project-file: ${{ inputs.project-file }}


### PR DESCRIPTION
## Summary
- add composite action `action.yml` that pins upstream missing-in-project to specific commit

## Testing
- `yamllint action.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a2583cf3883299ee6b28847df4fab