### PR TITLE
Ensure Bash for arch validation step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,7 @@ runs:
           echo "arch must be 32 or 64" >&2
           exit 1
         fi
+      shell: bash
     - name: Run upstream action
       id: inner
       uses: LabVIEW-Community-CI-CD/missing-in-project@6ef6511c58cbf74dca00498b5e05ca5690515f48  # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Summary
- run architecture check script explicitly with the Bash shell

## Testing
- `yamllint action.yml`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a312e08f08329ab2a63c6cb909dc2