### PR TITLE
Validate lv-ver input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,10 @@ runs:
           echo "arch must be 32 or 64" >&2
           exit 1
         fi
+        if [[ ! "${{ inputs['lv-ver'] }}" =~ ^[0-9]{4}$ ]]; then
+          echo "lv-ver must be a four-digit year (e.g., '2021')" >&2
+          exit 1
+        fi
       shell: bash
     - name: Run upstream action
       id: inner


### PR DESCRIPTION
## Summary
- validate that `lv-ver` input is a four-digit year

## Testing
- `yamllint action.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a3203c6148329aa18945ec1e67103