### PR TITLE
Validate project file existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This action wraps [LabVIEW-Community-CI-CD/missing-in-project](https://github.com/LabVIEW-Community-CI-CD/missing-in-project)
 and pins it to a specific commit to ensure stable builds. When the upstream action updates and is verified, this repository will
 update the pinned commit and communicate the change through release notes.
+
+Before invoking the upstream action, this wrapper validates the inputs and
+fails early if the specified project file does not exist.

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ runs:
           echo "arch must be 32 or 64" >&2
           exit 1
         fi
+        # Ensure the specified project file exists
+        if [[ ! -f "${{ inputs['project-file'] }}" ]]; then
+          echo "project-file '${{ inputs['project-file'] }}' not found" >&2
+          exit 1
+        fi
         if [[ ! "${{ inputs['lv-ver'] }}" =~ ^[0-9]{4}$ ]]; then
           echo "lv-ver must be a four-digit year (e.g., '2021')" >&2
           exit 1


### PR DESCRIPTION
## Summary
- fail early if specified project file is missing
- document project-file existence check

## Testing
- `yamllint action.yml`


------
https://chatgpt.com/codex/tasks/task_e_689a32ff9bdc8329bb9c446258d95dcc