### PR TITLE
Format missing file output as newline list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ update the pinned commit and communicate the change through release notes.
 
 Before invoking the upstream action, this wrapper validates the inputs and
 fails early if the specified project file does not exist.
+
+## Release Notes
+
+- `missing-files` output now returns a newline-separated list instead of a comma-separated list. Update parsing logic accordingly.

--- a/action.yml
+++ b/action.yml
@@ -27,8 +27,8 @@ outputs:
     description: "True if VI reported success."
     value: ${{ steps.inner.outputs.passed }}
   missing-files:
-    description: "Comma-separated list of missing files."
-    value: ${{ steps.inner.outputs['missing-files'] }}
+    description: "Newline-separated list of missing files."
+    value: ${{ steps.format.outputs['missing-files'] }}
 
 runs:
   using: composite
@@ -56,3 +56,16 @@ runs:
         lv-ver: ${{ inputs.lv-ver }}
         arch: ${{ inputs.arch }}
         project-file: ${{ inputs.project-file }}
+    - name: Format missing files
+      id: format
+      run: |
+        missing_files="${{ steps.inner.outputs['missing-files'] }}"
+        if [[ -n "$missing_files" ]]; then
+          missing_files=$(printf '%s' "$missing_files" | tr ',' '\n')
+        fi
+        {
+          echo 'missing-files<<EOF'
+          echo "$missing_files"
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+      shell: bash


### PR DESCRIPTION
## Summary
- expose `missing-files` output as newline-separated list
- document new output format in README

## Testing
- `actionlint`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3440f0748329beef69442b18f891