### PR TITLE
Enable strict bash mode in composite action scripts

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
   steps:
     - name: Validate inputs
       run: |
+        set -euo pipefail
         if [[ "${{ inputs.arch }}" != "32" && \
               "${{ inputs.arch }}" != "64" ]]; then
           echo "arch must be 32 or 64" >&2
@@ -60,6 +61,7 @@ runs:
     - name: Format missing files
       id: format
       run: |
+        set -euo pipefail
         missing_files="${{ steps.inner.outputs['missing-files'] }}"
         if [[ -n "$missing_files" ]]; then
           missing_files=$(printf '%s' "$missing_files" | tr ',' '\n')


### PR DESCRIPTION
## Summary
- ensure validation step fails on unset variables and pipe errors
- enable strict bash handling in missing-files formatting

## Testing
- `yamllint action.yml`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/missing-in-project-action/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689a373d5d1c83299fd3e631250be0d0