### PR TITLE
Expose missing files count output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ outputs:
   missing-files:
     description: "Newline-separated list of missing files."
     value: ${{ steps.format.outputs['missing-files'] }}
+  missing-files-count:
+    description: "Number of missing files."
+    value: ${{ steps.format.outputs['missing-files-count'] }}
 
 runs:
   using: composite
@@ -63,12 +66,13 @@ runs:
       run: |
         set -euo pipefail
         missing_files="${{ steps.inner.outputs['missing-files'] }}"
-        if [[ -n "$missing_files" ]]; then
-          missing_files=$(printf '%s' "$missing_files" | tr ',' '\n')
-        fi
+        missing_files=$(printf '%s' "$missing_files" | tr ',\r' '\n' | \
+          sed '/^$/d')
+        count=$(printf '%s\n' "$missing_files" | wc -l)
         {
           echo 'missing-files<<EOF'
           echo "$missing_files"
           echo EOF
+          echo "missing-files-count=$count"
         } >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
## Summary
- expose the number of missing files as an output
- return count from "Format missing files" step

## Testing
- `yamllint action.yml`

------
https://chatgpt.com/codex/tasks/task_e_689a38368fec8329b92afc3642325fad