### PR TITLE
chore: pin to labview-icon-editor action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # Missing In Project (pinned)
 
-This action wraps [LabVIEW-Community-CI-CD/missing-in-project](https://github.com/LabVIEW-Community-CI-CD/missing-in-project)
-and pins it to a specific commit to ensure stable builds. When the upstream action updates and is verified, this repository will
-update the pinned commit and communicate the change through release notes.
+This action wraps the
+[`missing-in-project`][upstream-action]
+action from [`ni/labview-icon-editor`][repo] and pins it to a
+specific commit to ensure stable builds. When the upstream action updates and is
+verified, this repository will update the pinned commit and communicate the
+change through release notes.
 
 Before invoking the upstream action, this wrapper validates the inputs and
 fails early if the specified project file does not exist.
 
 ## Release Notes
 
-- `missing-files` output now returns a newline-separated list instead of a comma-separated list. Update parsing logic accordingly.
+- Pinned upstream action to commit [`204c218`][pinned-action] from
+  `ni/labview-icon-editor/.github/actions/missing-in-project`.
+- `missing-files` output now returns a newline-separated list instead of a
+  comma-separated list. Update parsing logic accordingly.
+
+[upstream-action]: https://github.com/ni/labview-icon-editor/tree/develop/.github/actions/missing-in-project
+[repo]: https://github.com/ni/labview-icon-editor
+[pinned-action]: https://github.com/ni/labview-icon-editor/tree/204c21874646c6571fceb3adf69e35cc939d61f7/.github/actions/missing-in-project

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 ---
 name: "Missing In Project (pinned)"
 description: >
-  Wrapper around LabVIEW-Community-CI-CD/missing-in-project that pins
-  the underlying action to a known good commit. Upstream repository:
-  https://github.com/LabVIEW-Community-CI-CD/missing-in-project
+  Wrapper around ni/labview-icon-editor's `.github/actions/missing-in-project`
+  that pins the underlying action to a known good commit. Upstream repository:
+  https://github.com/ni/labview-icon-editor
 author: "LabVIEW Community CI/CD"
 branding:
   icon: search
@@ -56,7 +56,7 @@ runs:
       shell: bash
     - name: Run upstream action
       id: inner
-      uses: LabVIEW-Community-CI-CD/missing-in-project@6ef6511c58cbf74dca00498b5e05ca5690515f48  # yamllint disable-line rule:line-length
+      uses: ni/labview-icon-editor/.github/actions/missing-in-project@204c21874646c6571fceb3adf69e35cc939d61f7  # yamllint disable-line rule:line-length
       with:
         lv-ver: ${{ inputs.lv-ver }}
         arch: ${{ inputs.arch }}


### PR DESCRIPTION
## Summary
- pin wrapper to `ni/labview-icon-editor/.github/actions/missing-in-project@204c21874646c6571fceb3adf69e35cc939d61f7`
- document new upstream source and pinned commit

## Testing
- `yamllint action.yml`
- `npx --yes markdownlint-cli README.md`


------
https://chatgpt.com/codex/tasks/task_e_689a3b2f0fdc8329a8a334eb1ea94285