### PR TITLE
Refine validation and output parsing in composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ change through release notes.
 Before invoking the upstream action, this wrapper validates the inputs and
 fails early if the specified project file does not exist.
 
+## Outputs
+
+- `passed` – True if the missing-file check reported success.
+- `missing-files` – Newline-separated list of files that could not be found.
+- `missing-files-count` – Number of entries in `missing-files`.
+
 ## Release Notes
 
 - Pinned upstream action to commit [`204c218`][pinned-action] from
   `ni/labview-icon-editor/.github/actions/missing-in-project`.
 - `missing-files` output now returns a newline-separated list instead of a
   comma-separated list. Update parsing logic accordingly.
+- Added default `arch` input, enforced `.lvproj` project-file extension, and
+  switched to CSV-based output parsing to preserve spaces and commas.
 
 [upstream-action]: https://github.com/ni/labview-icon-editor/tree/develop/.github/actions/missing-in-project
 [repo]: https://github.com/ni/labview-icon-editor

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,5 @@
 ---
+x-upstream-ref: &ref 204c21874646c6571fceb3adf69e35cc939d61f7
 name: "Missing In Project (pinned)"
 description: >
   Wrapper around ni/labview-icon-editor's `.github/actions/missing-in-project`
@@ -15,7 +16,8 @@ inputs:
     required: true
   arch:
     description: "Bitness (32 or 64)."
-    required: true
+    required: false
+    default: "64"
   project-file:
     description: >
       Path to the .lvproj to inspect. Defaults to `main.lvproj`.
@@ -39,14 +41,19 @@ runs:
     - name: Validate inputs
       run: |
         set -euo pipefail
-        if [[ "${{ inputs.arch }}" != "32" && \
-              "${{ inputs.arch }}" != "64" ]]; then
-          echo "arch must be 32 or 64" >&2
+        valid_arches=(32 64)
+        arch="${{ inputs.arch }}"
+        if [[ ! " ${valid_arches[*]} " =~ " ${arch} " ]]; then
+          echo "arch must be one of: ${valid_arches[*]}" >&2
           exit 1
         fi
-        # Ensure the specified project file exists
-        if [[ ! -f "${{ inputs['project-file'] }}" ]]; then
-          echo "project-file '${{ inputs['project-file'] }}' not found" >&2
+        pf="${{ inputs['project-file'] }}"
+        if [[ ! -f "$pf" ]]; then
+          echo "project-file '$pf' not found" >&2
+          exit 1
+        fi
+        if [[ "$pf" != *.lvproj ]]; then
+          echo "project-file must end with .lvproj" >&2
           exit 1
         fi
         if [[ ! "${{ inputs['lv-ver'] }}" =~ ^[0-9]{4}$ ]]; then
@@ -56,7 +63,7 @@ runs:
       shell: bash
     - name: Run upstream action
       id: inner
-      uses: ni/labview-icon-editor/.github/actions/missing-in-project@204c21874646c6571fceb3adf69e35cc939d61f7  # yamllint disable-line rule:line-length
+      uses: ni/labview-icon-editor/.github/actions/missing-in-project@*ref
       with:
         lv-ver: ${{ inputs.lv-ver }}
         arch: ${{ inputs.arch }}
@@ -65,14 +72,15 @@ runs:
       id: format
       run: |
         set -euo pipefail
-        missing_files="${{ steps.inner.outputs['missing-files'] }}"
-        missing_files=$(printf '%s' "$missing_files" | tr ',\r' '\n' | \
-          sed '/^$/d')
-        count=$(printf '%s\n' "$missing_files" | wc -l)
-        {
-          echo 'missing-files<<EOF'
-          echo "$missing_files"
-          echo EOF
-          echo "missing-files-count=$count"
-        } >> "$GITHUB_OUTPUT"
+        missing="${{ steps.inner.outputs['missing-files'] }}"
+        python3 - "$missing" >> "$GITHUB_OUTPUT" <<'PY'
+        import csv, io, sys
+        data = sys.argv[1].replace('\r', '')
+        reader = csv.reader([data])
+        files = [f for f in next(reader, []) if f]
+        print('missing-files<<EOF')
+        print('\n'.join(files))
+        print('EOF')
+        print(f'missing-files-count={len(files)}')
+        PY
       shell: bash


### PR DESCRIPTION
## Summary
- add default arch option and centralized upstream ref
- ensure project file ends with .lvproj and validate allowed bitness values
- parse missing-files with Python CSV to preserve spaces and commas
- document action outputs

## Testing
- `yamllint action.yml`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3cb88acc83299a77ae97289da09d